### PR TITLE
fix: resolve false drift in superset_role_permissions

### DIFF
--- a/internal/provider/role_permissions_resource.go
+++ b/internal/provider/role_permissions_resource.go
@@ -198,11 +198,15 @@ func (r *rolePermissionsResource) Create(ctx context.Context, req resource.Creat
 	tflog.Debug(ctx, "Create method completed successfully")
 }
 
+// permissionSetKey builds a lookup key for a permission+view_menu pair.
+func permissionSetKey(permission, viewMenu string) string {
+	return permission + "|" + viewMenu
+}
+
 // Read refreshes the Terraform state with the latest data.
 func (r *rolePermissionsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	tflog.Debug(ctx, "Starting Read method")
 
-	// Get current state
 	var state rolePermissionsResourceModel
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -210,11 +214,6 @@ func (r *rolePermissionsResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	tflog.Debug(ctx, "State obtained", map[string]interface{}{
-		"roleName": state.RoleName.ValueString(),
-	})
-
-	// Get role ID
 	roleID, err := r.client.GetRoleIDByName(state.RoleName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -224,11 +223,6 @@ func (r *rolePermissionsResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	tflog.Debug(ctx, "Role ID obtained", map[string]interface{}{
-		"roleID": roleID,
-	})
-
-	// Get permissions from Superset
 	permissions, err := r.client.GetRolePermissions(roleID)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -238,78 +232,59 @@ func (r *rolePermissionsResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	tflog.Debug(ctx, "Permissions fetched from Superset", map[string]interface{}{
-		"permissions": permissions,
-	})
-
-	// Map permissions to resource model
-	var resourcePermissions []resourcePermissionModel
+	// Build lookup map from API response keyed by "permission|view_menu"
+	apiPermMap := make(map[string]client.Permission)
 	for _, perm := range permissions {
-		tflog.Debug(ctx, "Processing fetched permission", map[string]interface{}{
-			"ID":         perm.ID,
-			"Permission": perm.PermissionName,
-			"ViewMenu":   perm.ViewMenuName,
-		})
+		key := permissionSetKey(perm.PermissionName, perm.ViewMenuName)
+		apiPermMap[key] = perm
+	}
 
-		// Create mapped permission
-		mappedPermission := resourcePermissionModel{
-			ID:         types.Int64Value(perm.ID),
-			Permission: types.StringValue(perm.PermissionName),
-			ViewMenu:   types.StringValue(perm.ViewMenuName),
+	// Build set of state keys for comparison
+	stateKeys := make(map[string]bool)
+	for _, sp := range state.ResourcePermissions {
+		key := permissionSetKey(sp.Permission.ValueString(), sp.ViewMenu.ValueString())
+		stateKeys[key] = true
+	}
+
+	// Check if the set of permissions is identical (same keys, same count)
+	setsMatch := len(stateKeys) == len(apiPermMap)
+	if setsMatch {
+		for key := range stateKeys {
+			if _, ok := apiPermMap[key]; !ok {
+				setsMatch = false
+				break
+			}
 		}
-
-		// Verify mapping immediately after setting the values
-		tflog.Debug(ctx, "Mapped Permission", map[string]interface{}{
-			"ID":         mappedPermission.ID.ValueInt64(),
-			"Permission": mappedPermission.Permission.ValueString(),
-			"ViewMenu":   mappedPermission.ViewMenu.ValueString(),
-		})
-
-		resourcePermissions = append(resourcePermissions, mappedPermission)
 	}
 
-	// Debug full content of resourcePermissions by converting to a slice of maps
-	var debugResourcePermissions []map[string]interface{}
-	for _, rp := range resourcePermissions {
-		debugResourcePermissions = append(debugResourcePermissions, map[string]interface{}{
-			"ID":         rp.ID.ValueInt64(),
-			"Permission": rp.Permission.ValueString(),
-			"ViewMenu":   rp.ViewMenu.ValueString(),
-		})
+	if setsMatch {
+		tflog.Debug(ctx, "Permission sets match, preserving state ordering")
+		// Same permissions, possibly different order from API.
+		// Preserve existing state order, only update computed IDs.
+		for i, sp := range state.ResourcePermissions {
+			key := permissionSetKey(sp.Permission.ValueString(), sp.ViewMenu.ValueString())
+			if apiPerm, ok := apiPermMap[key]; ok {
+				state.ResourcePermissions[i].ID = types.Int64Value(apiPerm.ID)
+			}
+		}
+	} else {
+		tflog.Debug(ctx, "Permission sets differ, rebuilding state from API response")
+		// Permissions actually changed: rebuild from API response
+		var resourcePermissions []resourcePermissionModel
+		for _, perm := range permissions {
+			resourcePermissions = append(resourcePermissions, resourcePermissionModel{
+				ID:         types.Int64Value(perm.ID),
+				Permission: types.StringValue(perm.PermissionName),
+				ViewMenu:   types.StringValue(perm.ViewMenuName),
+			})
+		}
+		state.ResourcePermissions = resourcePermissions
 	}
 
-	tflog.Debug(ctx, "Full content of resourcePermissions", map[string]interface{}{
-		"resourcePermissions": debugResourcePermissions,
-	})
-
-	// Verify the final mapped permissions
-	// sort.Slice(resourcePermissions, func(i, j int) bool {
-	// 	return resourcePermissions[i].ID.ValueInt64() < resourcePermissions[j].ID.ValueInt64()
-	// })
-
-	for _, rp := range resourcePermissions {
-		tflog.Debug(ctx, "Mapped Permission in List", map[string]interface{}{
-			"ID":         rp.ID.ValueInt64(),
-			"Permission": rp.Permission.ValueString(),
-			"ViewMenu":   rp.ViewMenu.ValueString(),
-		})
-	}
-
-	tflog.Debug(ctx, "Final Permissions mapped to resource model", map[string]interface{}{
-		"resourcePermissions": debugResourcePermissions,
-	})
-
-	// Overwrite state with refreshed values
-	state.ResourcePermissions = resourcePermissions
-	state.LastUpdated = types.StringValue(time.Now().Format(time.RFC3339))
+	// Do NOT update last_updated in Read - it should only change on Create/Update
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	tflog.Debug(ctx, "Read method completed successfully")
 }
 
 // Update updates the resource and sets the updated Terraform state on success.

--- a/internal/provider/role_permissions_resource_test.go
+++ b/internal/provider/role_permissions_resource_test.go
@@ -210,4 +210,69 @@ func TestAccRolePermissionsResource(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("ReadPreservesOrderNoDrift", func(t *testing.T) {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder("POST", "http://superset-host/api/v1/security/login",
+			httpmock.NewStringResponder(200, `{"access_token": "fake-token"}`))
+
+		httpmock.RegisterResponder("GET", "http://superset-host/api/v1/security/roles?q=(page_size:5000)",
+			httpmock.NewStringResponder(200, `{"result": [{"id": 129, "name": "DWH-DB-Connect"}]}`))
+
+		httpmock.RegisterResponder("GET", "http://superset-host/api/v1/security/permissions-resources?q=(page_size:5000)",
+			httpmock.NewStringResponder(200, `{"result": [
+				{"id": 240, "permission": {"name": "database_access"}, "view_menu": {"name": "[SelfPostgreSQL].(id:1)"}},
+				{"id": 241, "permission": {"name": "schema_access"}, "view_menu": {"name": "[Trino].[devoriginationzestorage]"}}
+			]}`))
+
+		httpmock.RegisterResponder("POST", "http://superset-host/api/v1/security/roles/129/permissions",
+			httpmock.NewStringResponder(200, `{"status": "success"}`))
+
+		// API returns permissions in REVERSED order from config
+		httpmock.RegisterResponder("GET", "http://superset-host/api/v1/security/roles/129/permissions/",
+			httpmock.NewStringResponder(200, `{"result": [
+				{"id": 241, "permission_name": "schema_access", "view_menu_name": "[Trino].[devoriginationzestorage]"},
+				{"id": 240, "permission_name": "database_access", "view_menu_name": "[SelfPostgreSQL].(id:1)"}
+			]}`))
+
+		httpmock.RegisterResponder("DELETE", "http://superset-host/api/v1/security/roles/129/permissions",
+			httpmock.NewStringResponder(204, ""))
+
+		config := providerConfig + `
+resource "superset_role_permissions" "team" {
+  role_name            = "DWH-DB-Connect"
+  resource_permissions = [
+    {
+      permission = "database_access"
+      view_menu  = "[SelfPostgreSQL].(id:1)"
+    },
+    {
+      permission = "schema_access"
+      view_menu  = "[Trino].[devoriginationzestorage]"
+    },
+  ]
+}
+`
+
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: config,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("superset_role_permissions.team", "resource_permissions.#", "2"),
+						resource.TestCheckResourceAttr("superset_role_permissions.team", "resource_permissions.0.permission", "database_access"),
+						resource.TestCheckResourceAttr("superset_role_permissions.team", "resource_permissions.1.permission", "schema_access"),
+					),
+				},
+				{
+					Config:   config,
+					PlanOnly: true,
+				},
+			},
+		})
+	})
+	
 }


### PR DESCRIPTION
## Problem

Every `terraform plan` shows changes to `superset_role_permissions` resources even when no actual permission changes were made. For example, a PR that only adds a new user triggers 7 additional false role permission updates, wasting ~4-5 minutes per pipeline run.

Fixes: #40 

## Root Cause

Two bugs in the `Read` method of `role_permissions_resource.go`:

1. **Non-deterministic API ordering**: The Superset API ([Flask-AppBuilder `list_role_permissions`](https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.4.1/flask_appbuilder/security/sqla/apis/role/api.py)) returns permissions via a SQLAlchemy relationship with no `ORDER BY`. The `Read` method was blindly overwriting state with whatever order the API returned. Since `resource_permissions` is a `ListNestedAttribute`, Terraform compares elements position-by-position and reordering = false drift.

2. **Timestamp drift**: `state.LastUpdated = time.Now()` was called on every Read, guaranteeing the timestamp changed on every `terraform plan`.

## Fix

**State-aware Read**: Instead of overwriting state with the API response, the Read method now compares the set of `(permission, view_menu)` pairs between the existing state and the API response:

- **If sets match** (same permissions, just different order): preserve the existing state ordering and only update the computed `id` fields.
- **If sets differ** (permissions actually added/removed): rebuild state from the API response.

Also removed `last_updated = time.Now()` from the Read method, it should only be set in Create/Update.

## Validation

- Confirmed the API returns no guaranteed ordering by reviewing the source code in [Flask-AppBuilder v4.4.1](https://github.com/dpgaspar/Flask-AppBuilder/blob/v4.4.1/flask_appbuilder/security/sqla/apis/role/api.py) (used by Superset 4.0.2)
- Approach validated against [Terraform core maintainer guidance](https://stackoverflow.com/questions/79100964/handle-reordered-list-attributes-in-terraform-provider) and [AWS provider precedent (PR #36897)](https://github.com/hashicorp/terraform-provider-aws/pull/36897)
- Added `ReadPreservesOrderNoDrift` unit test that mocks the API returning permissions in reversed order and verifies `PlanOnly: true` produces an empty plan

## Test

```bash
TF_ACC=1 go test ./internal/provider/ -run TestAccRolePermissionsResource/ReadPreservesOrderNoDrift -v
```

## Expected Result
Pipeline runs that only add a user should show:

```
Plan: 0 to add, 1 to change, 0 to destroy.
```

Instead of the previous 8 changes (7 false drift + 1 real).